### PR TITLE
Fix an issue where if there are multiple, multiple images fields on t…

### DIFF
--- a/field.multiple_images.php
+++ b/field.multiple_images.php
@@ -53,6 +53,7 @@ class Field_multiple_images {
             ),
             'upload_url' => $upload_url,
             'is_new' => empty($entry_id),
+            'images' => array(),
             'max_limit_images' => $field->field_data['max_limit_images']
         );
         if (!empty($entry_id)) {


### PR DESCRIPTION
…he same page and the first has images, but the second doesn't have any images, then the second will inherit the images from the first. Obviously this is not the intended behavior;
